### PR TITLE
Allow installation under Django 1.6

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,7 @@ packages = find:
 include_package_data = true
 python_requires = >=2.7, <3.0
 install_requires =
-    django >= 1.4, <1.5
+    django >= 1.4, <1.7
 
 # Building
 


### PR DESCRIPTION
No more changes were needed as this is already compatible with Django 1.6